### PR TITLE
separate lint from test

### DIFF
--- a/generators/package/templates/package.json
+++ b/generators/package/templates/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "start-storybook -p 9001",
     "lint": "eslint . --ignore-pattern coverage node_modules",
-    "test": "yarn run lint && sh ../../package_test.sh",
+    "test": "sh ../../package_test.sh",
     "test-update": "jest -u --config=../../.jestrc.json"
   },
   "author": "<%= email %>",


### PR DESCRIPTION
The new project wide linting process [see this PR](https://github.com/bufferapp/buffer-analyze/pull/16) is not relying on the packages linting command anymore; therefore we need to remove it from here to avoid linting it twice.